### PR TITLE
major: credential을 생성자에서 받고 login을 없애도록 수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Client lib of the camp
 
 # Installation
 ```bash
-$ y add install the-camp
+$ pnpm add the-camp
 ```
 
 # Usage
@@ -20,7 +20,7 @@ async function main() {
 		password: 'password',
 	});
 
-	const soldierIdentifier = await theCampClient.registerSoldier({
+	const { soldierId } = await theCampClient.registerSoldier({
 		성분: '예비군인/훈련병',
 		군종: '육군',
 		이름: '홍길동',
@@ -31,7 +31,7 @@ async function main() {
 		전화번호: '01094862564',
 	});
 
-	await theCampClient.sendLetter(soldierIdentifier, {
+	await theCampClient.sendLetter(soldierId, {
 		작성자: '장지훈',
 		제목: `내용은 곧 제목22`,
 		내용: `제목은 곧 내용`,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "the-camp",
-	"version": "1.1.0",
+	"version": "2.0.0",
 	"main": "lib/index.js",
 	"types": "lib/index.d.ts",
 	"module": "esm/index.js",

--- a/src/client/the-camp.client.e2e.spec.ts
+++ b/src/client/the-camp.client.e2e.spec.ts
@@ -1,15 +1,14 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { TheCampClient } from './the-camp.client';
 
 describe('TheCampClient e2e', () => {
 	it('성공', async () => {
-		const theCampClient = new TheCampClient();
-
-		await theCampClient.login({
+		const theCampClient = new TheCampClient({
 			id: process.env.ID!,
 			password: process.env.PASSWORD!,
 		});
 
-		const soldierIdentifier = await theCampClient.registerSoldier({
+		const { soldierId } = await theCampClient.registerSoldier({
 			성분: '예비군인/훈련병',
 			군종: '육군',
 			이름: '홍길동',
@@ -20,7 +19,7 @@ describe('TheCampClient e2e', () => {
 			전화번호: '01094862564',
 		});
 
-		await theCampClient.sendLetter(soldierIdentifier, {
+		await theCampClient.sendLetter(soldierId, {
 			작성자: '장지훈',
 			제목: `내용은 곧 제목22`,
 			내용: `제목은 곧 내용`,


### PR DESCRIPTION
login을 호출해야 사용 가능한 상태가 되는 부분을 없애고자 credential을 생성자에서 받도록 수정하였습니다
soldierIdentifier가 object이다보니 저장/이동 시키기 힘들고 추후 확장과 같은 변경에 대응이 힘들 것 같아 string 으로 수정하였습니다
